### PR TITLE
fix SetMesh warning

### DIFF
--- a/ImGuiNET.Unity/Renderer/ImGuiRendererMesh.cs
+++ b/ImGuiNET.Unity/Renderer/ImGuiRendererMesh.cs
@@ -33,7 +33,7 @@ namespace ImGuiNET.Unity
         const MeshUpdateFlags NoMeshChecks = MeshUpdateFlags.DontNotifyMeshUsers | MeshUpdateFlags.DontRecalculateBounds
                                            | MeshUpdateFlags.DontResetBoneBounds | MeshUpdateFlags.DontValidateIndices;
         int _prevSubMeshCount = 1;  // number of sub meshes used previously
-
+        List<SubMeshDescriptor> descriptors = new List<SubMeshDescriptor>();
         static readonly ProfilerMarker s_updateMeshPerfMarker = new ProfilerMarker("DearImGui.RendererMesh.UpdateMesh");
         static readonly ProfilerMarker s_createDrawComandsPerfMarker = new ProfilerMarker("DearImGui.RendererMesh.CreateDrawCommands");
 
@@ -97,7 +97,7 @@ namespace ImGuiNET.Unity
             // upload data into mesh
             int vtxOf = 0;
             int idxOf = 0;
-            List<SubMeshDescriptor> descriptors = new List<SubMeshDescriptor>();
+            
             for (int n = 0, nMax = drawData.CmdListsCount; n < nMax; ++n)
             {
                 ImDrawListPtr drawList = drawData.CmdListsRange[n];
@@ -113,7 +113,7 @@ namespace ImGuiNET.Unity
                 // upload vertex/index data
                 _mesh.SetVertexBufferData(vtxArray, 0, vtxOf, vtxArray.Length, 0, NoMeshChecks);
                 _mesh.SetIndexBufferData (idxArray, 0, idxOf, idxArray.Length,    NoMeshChecks);
-
+                descriptors.Clear();
                 // define subMeshes
                 for (int i = 0, iMax = drawList.CmdBuffer.Size; i < iMax; ++i)
                 {

--- a/ImGuiNET.Unity/Renderer/ImGuiRendererMesh.cs
+++ b/ImGuiNET.Unity/Renderer/ImGuiRendererMesh.cs
@@ -3,6 +3,7 @@ using UnityEngine.Rendering;
 using Unity.Collections;
 using Unity.Collections.LowLevel.Unsafe;
 using Unity.Profiling;
+using System.Collections.Generic;
 
 namespace ImGuiNET.Unity
 {
@@ -96,7 +97,7 @@ namespace ImGuiNET.Unity
             // upload data into mesh
             int vtxOf = 0;
             int idxOf = 0;
-            int subOf = 0;
+            List<SubMeshDescriptor> descriptors = new List<SubMeshDescriptor>();
             for (int n = 0, nMax = drawData.CmdListsCount; n < nMax; ++n)
             {
                 ImDrawListPtr drawList = drawData.CmdListsRange[n];
@@ -124,11 +125,12 @@ namespace ImGuiNET.Unity
                         indexCount = (int)cmd.ElemCount,
                         baseVertex = vtxOf + (int)cmd.VtxOffset,
                     };
-                    _mesh.SetSubMesh(subOf++, descriptor, NoMeshChecks);
+                    descriptors.Add(descriptor);
                 }
                 vtxOf += vtxArray.Length;
                 idxOf += idxArray.Length;
             }
+            _mesh.SetSubMeshes(descriptors, NoMeshChecks);
             _mesh.UploadMeshData(false);
         }
 

--- a/Plugins/System.Runtime.CompilerServices.Unsafe.dll
+++ b/Plugins/System.Runtime.CompilerServices.Unsafe.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:52fb179fb0ec10918a3f5115c9a7290222e22886d173aab4509580824ff5be37
+size 16776

--- a/Plugins/System.Runtime.CompilerServices.Unsafe.dll.meta
+++ b/Plugins/System.Runtime.CompilerServices.Unsafe.dll.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: 3a444c26ba4032048822eddd48e2d346
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
get warning in unity2020.3.0f1c1

SetSubMesh #1 shares part of its index buffer with SubMesh #2. Sharing part of an index buffer can result in undefined behavior and will be deprecated soon. To future-proof your Project, fix the indexStart/indexCount
UnityEngine.Mesh:SetSubMesh (int,UnityEngine.Rendering.SubMeshDescriptor,UnityEngine.Rendering.MeshUpdateFlags)
ImGuiNET.Unity.ImGuiRendererMesh:UpdateMesh (ImGuiNET.ImDrawDataPtr,UnityEngine.Vector2) (at Packages/dear-imgui-unity/ImGuiNET.Unity/Renderer/ImGuiRendererMesh.cs:127)
ImGuiNET.Unity.ImGuiRendererMesh:RenderDrawLists (UnityEngine.Rendering.CommandBuffer,ImGuiNET.ImDrawDataPtr) (at Packages/dear-imgui-unity/ImGuiNET.Unity/Renderer/ImGuiRendererMesh.cs:71)
ImGuiNET.Unity.DearImGui:Update () (at Packages/dear-imgui-unity/ImGuiNET.Unity/DearImGui.cs:157)